### PR TITLE
fix: update task with new api version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(deep_trekker VERSION 0.0)
 
-set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.orogen/config")
 include(deep_trekkerBase)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(deep_trekker VERSION 0.0)
 
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.orogen/config")
 include(deep_trekkerBase)
 

--- a/deep_trekker.orogen
+++ b/deep_trekker.orogen
@@ -27,8 +27,10 @@ task_context "RevolutionTask" do
 
     # Tilt camera head position/speed joint command
     input_port "tilt_camera_head_command", "base/samples/Joints"
-    # Camera head laser, light and camera commands
-    input_port "camera_head_command", "deep_trekker/CameraHeadCommand"
+    # Camera head light command
+    input_port "camera_head_light", "double"
+    # Camera head laser command
+    input_port "camera_head_laser_enable", "bool"
     # Grabber raw joint commands
     input_port "grabber_command", "base/samples/Joints"
     # Vehicle setpoint in local frame
@@ -44,13 +46,15 @@ task_context "RevolutionTask" do
 
     # Rawdata out
     output_port "data_out", "iodrivers_base/RawPacket"
-    # Revolution states
+    # Revolution camera head state
     output_port "camera_head_states", "deep_trekker/TiltCameraHead"
-    # Revolution states
+    # Revolution camera head tilt state
     output_port "camera_head_tilt_states", "base/samples/Joints"
+    # Revolution camera head tilt state in rigid body state form
+    output_port "camera_head_tilt_states_rbs", "base/samples/RigidBodyState"
     # Revolution states
     output_port "revolution_states", "deep_trekker/Revolution"
-    # Revolution pose
+    # Revolution pose (z and attitude)
     output_port "revolution_pose_z_attitude", "base/samples/RigidBodyState"
     # Revolution motor states
     output_port "revolution_motor_states", "base/samples/Joints"

--- a/deep_trekker.orogen
+++ b/deep_trekker.orogen
@@ -19,6 +19,9 @@ task_context "RevolutionTask" do
     property "devices_id", "deep_trekker/DevicesID"
     # For how long an input will be repeated before timing out
     property "input_timeout", "base/Time"
+    # Camera head tilt limits
+    property "camera_head_limits", "deep_trekker/CameraHeadLimits"
+
 
     # Tilt camera head position/speed joint command
     input_port "tilt_camera_head_command", "base/samples/Joints"

--- a/deep_trekker.orogen
+++ b/deep_trekker.orogen
@@ -13,8 +13,12 @@ task_context "RevolutionTask" do
 
     # API version
     property "api_version", "std/string"
+    # The model number of each device
     property "devices_model", "deep_trekker/DevicesModel"
+    # The IDs of each device
     property "devices_id", "deep_trekker/DevicesID"
+    # For how long an input will be repeated before timing out
+    property "input_timeout", "base/Time"
 
     # Tilt camera head position/speed joint command
     input_port "tilt_camera_head_command", "base/samples/Joints"
@@ -36,6 +40,10 @@ task_context "RevolutionTask" do
     # Rawdata out
     output_port "data_out", "iodrivers_base/RawPacket"
     # Revolution states
+    output_port "camera_head_states", "deep_trekker/TiltCameraHead"
+    # Revolution states
+    output_port "camera_head_tilt_states", "base/samples/Joints"
+    # Revolution states
     output_port "revolution_states", "deep_trekker/Revolution"
     # Revolution pose
     output_port "revolution_pose_z_attitude", "base/samples/RigidBodyState"
@@ -50,5 +58,5 @@ task_context "RevolutionTask" do
     # Manual reel states
     output_port "manual_reel_states", "deep_trekker/ManualReel"
 
-    port_driven
+    periodic 0.005
 end

--- a/deep_trekker.orogen
+++ b/deep_trekker.orogen
@@ -13,55 +13,40 @@ task_context "RevolutionTask" do
 
     # API version
     property "api_version", "std/string"
-
-    # Devices mac adress
-    property "devices_mac_address", "deep_trekker/DevicesMacAddress"
-
-    # API version
-    property "motion_controller_type", "deep_trekker/MotionControllerType"
+    property "devices_model", "deep_trekker/DevicesModel"
+    property "devices_id", "deep_trekker/DevicesID"
 
     # Tilt camera head position/speed joint command
     input_port "tilt_camera_head_command", "base/samples/Joints"
-
     # Camera head laser, light and camera commands
     input_port "camera_head_command", "deep_trekker/CameraHeadCommand"
-
     # Grabber raw joint commands
     input_port "grabber_command", "base/samples/Joints"
-
     # Vehicle setpoint in local frame
-    input_port "rov2ref_command", "base/commands/LinearAngular6DCommand"
-
+    input_port "drive_command", "base/commands/LinearAngular6DCommand"
+    # Vehicle setpoint in local frame
+    input_port "drive_mode_command", "deep_trekker/DriveMode"
     # Vehicle light command
     input_port "light_command", "double"
-
     # Powered reel speed joint command
     input_port "powered_reel_command", "base/samples/Joints"
-
     # Rawdata in
     input_port "data_in", "iodrivers_base/RawPacket"
 
     # Rawdata out
     output_port "data_out", "iodrivers_base/RawPacket"
-
     # Revolution states
     output_port "revolution_states", "deep_trekker/Revolution"
-
-    # Revolution body states
-    output_port "revolution_body_states", "base/samples/RigidBodyState"
-
+    # Revolution pose
+    output_port "revolution_pose_z_attitude", "base/samples/RigidBodyState"
     # Revolution motor states
     output_port "revolution_motor_states", "base/samples/Joints"
-
     # Grabber motor states
-    output_port "grabber_motor_states", "base/samples/Joints"
-
+    output_port "grabber_motor_states", "deep_trekker/Grabber"
     # Powered reel states
     output_port "powered_reel_states", "deep_trekker/PoweredReel"
-
     # Powered reel motor states
     output_port "powered_reel_motor_states", "base/samples/Joints"
-
     # Manual reel states
     output_port "manual_reel_states", "deep_trekker/ManualReel"
 

--- a/deep_trekker.orogen
+++ b/deep_trekker.orogen
@@ -21,6 +21,8 @@ task_context "RevolutionTask" do
     property "input_timeout", "base/Time"
     # Camera head tilt limits
     property "camera_head_limits", "deep_trekker/CameraHeadLimits"
+    # Minimum speed command for vertical thrusters to counteract buoyancy
+    property "vertical_thrusters_minimum_command", "double"
 
 
     # Tilt camera head position/speed joint command

--- a/tasks/RevolutionTask.cpp
+++ b/tasks/RevolutionTask.cpp
@@ -41,6 +41,7 @@ bool RevolutionTask::configureHook()
     m_devices_model = _devices_model.get();
     m_devices_id = _devices_id.get();
     m_input_timeout = _input_timeout.get();
+    m_camera_head_limits = _camera_head_limits.get();
 
     return true;
 }
@@ -118,6 +119,18 @@ void RevolutionTask::evaluateTiltCameraHeadCommand()
     }
 
     if (Time::now() > m_deadlines.tilt_camera_head) {
+        return;
+    }
+
+    if (isUnknown(m_camera_head_tilt_position)) {
+        return;
+    }
+    if (m_camera_head_tilt_position >= m_camera_head_limits.upper &&
+        tilt_camera_head_command.elements[0].speed > 0) {
+        return;
+    }
+    if (m_camera_head_tilt_position <= m_camera_head_limits.lower &&
+        tilt_camera_head_command.elements[0].speed < 0) {
         return;
     }
 

--- a/tasks/RevolutionTask.cpp
+++ b/tasks/RevolutionTask.cpp
@@ -42,6 +42,7 @@ bool RevolutionTask::configureHook()
     m_devices_id = _devices_id.get();
     m_input_timeout = _input_timeout.get();
     m_camera_head_limits = _camera_head_limits.get();
+    m_vertical_thrusters_minimum_command = _vertical_thrusters_minimum_command.get();
 
     return true;
 }
@@ -91,7 +92,8 @@ void RevolutionTask::evaluateDriveCommand()
         m_message_parser.parseDriveRevolutionCommandMessage(m_api_version,
             m_devices_id.revolution,
             m_devices_model.revolution,
-            drive);
+            drive,
+            m_vertical_thrusters_minimum_command);
     sendRawDataOutput(drive_command);
 }
 

--- a/tasks/RevolutionTask.cpp
+++ b/tasks/RevolutionTask.cpp
@@ -1,6 +1,7 @@
 /* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
 
 #include "RevolutionTask.hpp"
+#include <algorithm>
 
 using namespace std;
 using namespace base;
@@ -16,6 +17,15 @@ RevolutionTask::~RevolutionTask()
 {
 }
 
+void tryWriteIgnoringExceptions(function<void()> write_func)
+{
+    try {
+        write_func();
+    }
+    catch (invalid_argument& e) {
+    }
+}
+
 /// The following lines are template definitions for the various state machine
 // hooks defined by Orocos::RTT. See RevolutionTask.hpp for more detailed
 // documentation about them.
@@ -25,9 +35,9 @@ bool RevolutionTask::configureHook()
     if (!RevolutionTaskBase::configureHook()) {
         return false;
     }
-    mDevicesMacAddress = _devices_mac_address.get();
-    mAPIVersion = _api_version.get();
-    mMotionControllerType = _motion_controller_type.get();
+    m_api_version = _api_version.get();
+    m_devices_model = _devices_model.get();
+    m_devices_id = _devices_id.get();
 
     return true;
 }
@@ -38,161 +48,116 @@ bool RevolutionTask::startHook()
         return false;
     }
 
-    // Query device info first
-    queryNewDeviceStateInfo();
-
     return true;
 }
 
 void RevolutionTask::updateHook()
 {
-    queryNewDeviceStateInfo();
-
     receiveDeviceStateInfo();
 
-    evaluateCameraHeadCommand();
+    if (!m_devices_id.revolution.empty()) {
+        evaluateCameraHeadCommand();
+        evaluateTiltCameraHeadCommand();
+        evaluateGrabberCommand();
+        evaluateDriveCommand();
+        evaluateDriveModeCommand();
+    }
 
-    evaluateGrabberCommand();
-
-    evaluateMotionController();
-
-    evaluatePoweredReelControlCommand();
+    if (!m_devices_id.powered_reel.empty()) {
+        evaluatePoweredReelControlCommand();
+    }
 
     RevolutionTaskBase::updateHook();
 }
 
-void RevolutionTask::evaluateCameraHeadCommand()
+void RevolutionTask::evaluateDriveCommand()
+{
+    base::commands::LinearAngular6DCommand drive;
+    if (_drive_command.read(drive) == RTT::NoData) {
+        return;
+    }
+
+    string drive_command =
+        m_message_parser.parseDriveRevolutionCommandMessage(m_api_version,
+            m_devices_id.revolution,
+            m_devices_model.revolution,
+            drive);
+    sendRawDataOutput(drive_command);
+}
+
+void RevolutionTask::evaluateDriveModeCommand()
+{
+    DriveMode mode;
+    if (_drive_mode_command.read(mode) == RTT::NoData) {
+        return;
+    }
+
+    string mode_command =
+        m_message_parser.parseDriveModeRevolutionCommandMessage(m_api_version,
+            m_devices_id.revolution,
+            m_devices_model.revolution,
+            mode);
+    sendRawDataOutput(mode_command);
+}
+
+void RevolutionTask::evaluateTiltCameraHeadCommand()
 {
     samples::Joints tilt_camera_head_command;
     if (_tilt_camera_head_command.read(tilt_camera_head_command) == RTT::NoData) {
         return;
     }
 
+    string address = m_devices_id.revolution;
+    string control_command =
+        m_message_parser.parseTiltCameraHeadCommandMessage(m_api_version,
+            address,
+            m_devices_model.revolution,
+            tilt_camera_head_command);
+    sendRawDataOutput(control_command);
+}
+
+void RevolutionTask::evaluateCameraHeadCommand()
+{
     CameraHeadCommand camera_head_command;
-    if (_camera_head_command.read(camera_head_command) != RTT::NewData) {
+    if (_camera_head_command.read(camera_head_command) == RTT::NoData) {
         return;
     }
 
-    string address = mDevicesMacAddress.revolution;
-    string control_command = mMessageParser.parseTiltCameraHeadCommandMessage(mAPIVersion,
+    string address = m_devices_id.revolution;
+    string control_command = m_message_parser.parseCameraHeadCommandMessage(m_api_version,
         address,
-        camera_head_command,
-        tilt_camera_head_command);
+        m_devices_model.revolution,
+        camera_head_command);
     sendRawDataOutput(control_command);
 }
 
 void RevolutionTask::evaluateGrabberCommand()
 {
     samples::Joints grabber_command;
-    if (_grabber_command.read(grabber_command) != RTT::NewData) {
+    if (_grabber_command.read(grabber_command) == RTT::NoData) {
         return;
     }
 
-    string address = mDevicesMacAddress.revolution;
-    string control_command =
-        mMessageParser.parseGrabberCommandMessage(mAPIVersion, address, grabber_command);
+    string address = m_devices_id.revolution;
+    string control_command = m_message_parser.parseGrabberCommandMessage(m_api_version,
+        address,
+        grabber_command);
     sendRawDataOutput(control_command);
-}
-
-void RevolutionTask::evaluatePositionAndLightCommand()
-{
-    commands::LinearAngular6DCommand rov2ref_command;
-    if (_rov2ref_command.read(rov2ref_command) != RTT::NewData) {
-        return;
-    }
-
-    double light_command;
-    if (_light_command.read(light_command) == RTT::NoData) {
-        return;
-    }
-    MotionAndLightCommand command;
-    command.light = light_command;
-    command.vehicle_setpoint = rov2ref_command;
-
-    string address = mDevicesMacAddress.revolution;
-    string control_command =
-        mMessageParser.parsePositionRevolutionCommandMessage(mAPIVersion,
-            address,
-            command);
-    sendRawDataOutput(control_command);
-}
-
-void RevolutionTask::evaluateVelocityAndLightCommand()
-{
-    commands::LinearAngular6DCommand rov2ref_command;
-    if (_rov2ref_command.read(rov2ref_command) != RTT::NewData) {
-        return;
-    }
-
-    double light_command;
-    if (_light_command.read(light_command) == RTT::NoData) {
-        return;
-    }
-    MotionAndLightCommand command;
-    command.light = light_command;
-    command.vehicle_setpoint = rov2ref_command;
-
-    string address = mDevicesMacAddress.revolution;
-    string control_command =
-        mMessageParser.parseVelocityRevolutionCommandMessage(mAPIVersion,
-            address,
-            command);
-    sendRawDataOutput(control_command);
-}
-
-void RevolutionTask::evaluateAccelerationAndLightCommand()
-{
-    commands::LinearAngular6DCommand rov2ref_command;
-    if (_rov2ref_command.read(rov2ref_command) != RTT::NewData) {
-        return;
-    }
-
-    double light_command;
-    if (_light_command.read(light_command) == RTT::NoData) {
-        return;
-    }
-    MotionAndLightCommand command;
-    command.light = light_command;
-    command.vehicle_setpoint = rov2ref_command;
-
-    string address = mDevicesMacAddress.revolution;
-    string control_command =
-        mMessageParser.parseAccelerationRevolutionCommandMessage(mAPIVersion,
-            address,
-            command);
-    sendRawDataOutput(control_command);
-}
-
-void RevolutionTask::evaluateMotionController()
-{
-    switch (mMotionControllerType) {
-        case position: {
-            evaluatePositionAndLightCommand();
-            return;
-        }
-        case velocity: {
-            evaluateVelocityAndLightCommand();
-            return;
-        }
-        case acceleration:
-            evaluateAccelerationAndLightCommand();
-            return;
-        default:
-            break;
-    }
 }
 
 void RevolutionTask::evaluatePoweredReelControlCommand()
 {
     samples::Joints powered_reel_command;
-    if (_powered_reel_command.read(powered_reel_command) != RTT::NewData) {
+    if (_powered_reel_command.read(powered_reel_command) == RTT::NoData) {
         return;
     }
 
-    string address = mDevicesMacAddress.powered_reel;
-    string control_command = mMessageParser.parsePoweredReelCommandMessage(mAPIVersion,
-        address,
-        powered_reel_command);
+    string address = m_devices_id.powered_reel;
+    string control_command =
+        m_message_parser.parsePoweredReelCommandMessage(m_api_version,
+            address,
+            m_devices_model.powered_reel,
+            powered_reel_command);
     sendRawDataOutput(control_command);
 }
 
@@ -206,13 +171,6 @@ void RevolutionTask::sendRawDataOutput(string control_command)
     _data_out.write(data_out);
 }
 
-void RevolutionTask::queryNewDeviceStateInfo()
-{
-    mMessageParser = CommandAndStateMessageParser();
-    string get_message = mMessageParser.parseGetMessage(mAPIVersion);
-    sendRawDataOutput(get_message);
-}
-
 void RevolutionTask::receiveDeviceStateInfo()
 {
     RawPacket data_in;
@@ -222,139 +180,123 @@ void RevolutionTask::receiveDeviceStateInfo()
 
     string error;
     string data_str(data_in.data.begin(), data_in.data.end());
-    if (!mMessageParser.parseJSONMessage(data_str.c_str(), error)) {
+    if (!m_message_parser.parseJSONMessage(data_str.c_str(), error)) {
         throw invalid_argument(error);
     }
-    if (!mDevicesMacAddress.revolution.empty()) {
-        _revolution_states.write(getRevolutionStates());
-        _revolution_body_states.write(getRevolutionBodyStates());
-        _revolution_motor_states.write(getRevolutionMotorStates());
-        _grabber_motor_states.write(getGrabberMotorStates());
+
+    if (!m_devices_id.revolution.empty()) {
+        tryWriteIgnoringExceptions(
+            [&]() { _revolution_states.write(getRevolutionStates()); });
+        tryWriteIgnoringExceptions(
+            [&]() { _revolution_motor_states.write(getRevolutionMotorStates()); });
+        tryWriteIgnoringExceptions(
+            [&]() { _grabber_motor_states.write(getGrabberMotorStates()); });
+        tryWriteIgnoringExceptions(
+            [&]() { _revolution_pose_z_attitude.write(getRevolutionPoseZAttitude()); });
     }
 
-    if (!mDevicesMacAddress.powered_reel.empty()) {
-        _powered_reel_states.write(getPoweredReelStates());
-        _powered_reel_motor_states.write(getPoweredReelMotorStates());
+    if (!m_devices_id.powered_reel.empty()) {
+        tryWriteIgnoringExceptions(
+            [&]() { _powered_reel_states.write(getPoweredReelStates()); });
+        tryWriteIgnoringExceptions(
+            [&]() { _powered_reel_motor_states.write(getPoweredReelMotorStates()); });
     }
 
-    if (!mDevicesMacAddress.manual_reel.empty()) {
-        _manual_reel_states.write(getManualReelStates());
+    if (!m_devices_id.manual_reel.empty()) {
+        tryWriteIgnoringExceptions(
+            [&]() { _manual_reel_states.write(getManualReelStates()); });
     }
 }
 
 Revolution RevolutionTask::getRevolutionStates()
 {
     Revolution revolution;
-    if (!mMessageParser.checkDeviceMacAddress(mDevicesMacAddress.revolution)) {
-        throw invalid_argument("Revolution mac address incorrect");
-    }
-    string rev_address = mDevicesMacAddress.revolution;
-    revolution.usage_time = mMessageParser.getTimeUsage(rev_address);
+
+    auto rev_address = m_devices_id.revolution;
+    revolution.usage_time = m_message_parser.getTimeUsage(rev_address);
     revolution.front_right_motor_overcurrent =
-        mMessageParser.getMotorOvercurrentStates(rev_address,
+        m_message_parser.getMotorOvercurrentStates(rev_address,
             "frontRightMotorDiagnostics");
     revolution.front_left_motor_overcurrent =
-        mMessageParser.getMotorOvercurrentStates(rev_address,
+        m_message_parser.getMotorOvercurrentStates(rev_address,
             "frontLeftMotorDiagnostics");
     revolution.rear_right_motor_overcurrent =
-        mMessageParser.getMotorOvercurrentStates(rev_address,
+        m_message_parser.getMotorOvercurrentStates(rev_address,
             "rearRightMotorDiagnostics");
     revolution.rear_left_motor_overcurrent =
-        mMessageParser.getMotorOvercurrentStates(rev_address, "rearLeftMotorDiagnostics");
+        m_message_parser.getMotorOvercurrentStates(rev_address,
+            "rearLeftMotorDiagnostics");
     revolution.vertical_right_motor_overcurrent =
-        mMessageParser.getMotorOvercurrentStates(rev_address,
+        m_message_parser.getMotorOvercurrentStates(rev_address,
             "verticalRightMotorDiagnostics");
     revolution.vertical_left_motor_overcurrent =
-        mMessageParser.getMotorOvercurrentStates(rev_address,
+        m_message_parser.getMotorOvercurrentStates(rev_address,
             "verticalLeftMotorDiagnostics");
-    revolution.vehicle_control = mMessageParser.getRevolutionControlStates(rev_address);
-    revolution.left_battery = mMessageParser.getBatteryStates(rev_address, "leftBattery");
+
+    revolution.left_battery =
+        m_message_parser.getBatteryStates(rev_address, "leftBattery");
     revolution.right_battery =
-        mMessageParser.getBatteryStates(rev_address, "rightBattery");
-    revolution.light = mMessageParser.getLightIntensity(rev_address);
-    revolution.grabber = mMessageParser.getGrabberMotorOvercurrentStates(rev_address);
-    revolution.camera_head = mMessageParser.getCameraHeadStates(rev_address);
+        m_message_parser.getBatteryStates(rev_address, "rightBattery");
+
+    revolution.aux_light = m_message_parser.getAuxLightIntensity(rev_address);
+    revolution.grabber = m_message_parser.getGrabberMotorOvercurrentStates(rev_address);
+    revolution.camera_head = m_message_parser.getCameraHeadStates(rev_address);
+    revolution.cameras = m_message_parser.getCameras(rev_address);
+    revolution.cpu_temperature = m_message_parser.getCpuTemperature(rev_address);
+    revolution.drive_modes = m_message_parser.getRevolutionDriveModes(rev_address);
+    revolution.timestamp = Time::now();
 
     return revolution;
 }
 
-samples::RigidBodyState RevolutionTask::getRevolutionBodyStates()
+samples::RigidBodyState RevolutionTask::getRevolutionPoseZAttitude()
 {
-    if (!mMessageParser.checkDeviceMacAddress(mDevicesMacAddress.revolution)) {
-        throw invalid_argument("Revolution mac address incorrect");
-    }
-    string rev_address = mDevicesMacAddress.revolution;
-
-    return mMessageParser.getRevolutionBodyStates(rev_address);
+    return m_message_parser.getRevolutionPoseZAttitude(m_devices_id.revolution);
 }
 
 samples::Joints RevolutionTask::getRevolutionMotorStates()
 {
-    if (!mMessageParser.checkDeviceMacAddress(mDevicesMacAddress.revolution)) {
-        throw invalid_argument("Revolution mac address incorrect");
-    }
-    string rev_address = mDevicesMacAddress.revolution;
-
-    return mMessageParser.getRevolutionMotorStates(rev_address);
+    return m_message_parser.getRevolutionMotorStates(m_devices_id.revolution);
 }
 
 PoweredReel RevolutionTask::getPoweredReelStates()
 {
-    PoweredReel powered_reel;
-    if (!mMessageParser.checkDeviceMacAddress(mDevicesMacAddress.powered_reel)) {
-        throw invalid_argument("Powered reel mac address incorrect");
-    }
-    string pwr_reel = mDevicesMacAddress.powered_reel;
-    powered_reel.calibrated = mMessageParser.isCalibrated(pwr_reel);
-    powered_reel.ready = mMessageParser.isReady(pwr_reel);
-    powered_reel.tether_lenght = mMessageParser.getTetherLenght(pwr_reel);
-    powered_reel.leak = mMessageParser.isLeaking(pwr_reel);
-    powered_reel.cpu_temperature = mMessageParser.getCpuTemperature(pwr_reel);
-    powered_reel.battery_1 = mMessageParser.getBatteryStates(pwr_reel, "battery1");
-    powered_reel.battery_2 = mMessageParser.getBatteryStates(pwr_reel, "battery2");
-    powered_reel.ac_power_connected = mMessageParser.isACPowerConnected(pwr_reel);
-    powered_reel.estop_enabled = mMessageParser.isEStopEnabled(pwr_reel);
-    powered_reel.motor_1_overcurrent =
-        mMessageParser.getMotorOvercurrentStates(pwr_reel, "motor1Diagnostics");
-    powered_reel.motor_2_overcurrent =
-        mMessageParser.getMotorOvercurrentStates(pwr_reel, "motor2Diagnostics");
+    string pwr_reel = m_devices_id.powered_reel;
 
+    PoweredReel powered_reel;
+    powered_reel.timestamp = Time::now();
+    powered_reel.tether_length = m_message_parser.getTetherLength(pwr_reel);
+    powered_reel.leak = m_message_parser.isLeaking(pwr_reel);
+    powered_reel.cpu_temperature = m_message_parser.getCpuTemperature(pwr_reel);
+    powered_reel.battery_1 = m_message_parser.getBatteryStates(pwr_reel, "battery1");
+    powered_reel.battery_2 = m_message_parser.getBatteryStates(pwr_reel, "battery2");
+    powered_reel.ac_power_connected = m_message_parser.isACPowerConnected(pwr_reel);
+    powered_reel.estop_enabled = m_message_parser.isEStopEnabled(pwr_reel);
+    powered_reel.motor_1_overcurrent =
+        m_message_parser.getMotorOvercurrentStates(pwr_reel, "motor1Diagnostics");
+    powered_reel.motor_2_overcurrent =
+        m_message_parser.getMotorOvercurrentStates(pwr_reel, "motor2Diagnostics");
     return powered_reel;
 }
 
 samples::Joints RevolutionTask::getPoweredReelMotorStates()
 {
-    if (!mMessageParser.checkDeviceMacAddress(mDevicesMacAddress.powered_reel)) {
-        throw invalid_argument("Powered reel mac address incorrect");
-    }
-    string pwr_reel = mDevicesMacAddress.powered_reel;
-
-    return mMessageParser.getPoweredReelMotorState(pwr_reel);
+    return m_message_parser.getPoweredReelMotorState(m_devices_id.powered_reel);
 }
 
-samples::Joints RevolutionTask::getGrabberMotorStates()
+Grabber RevolutionTask::getGrabberMotorStates()
 {
-    if (!mMessageParser.checkDeviceMacAddress(mDevicesMacAddress.revolution)) {
-        throw invalid_argument("Revolution mac address incorrect");
-    }
-    string rev_address = mDevicesMacAddress.revolution;
-
-    return mMessageParser.getGrabberMotorStates(rev_address);
+    return m_message_parser.getGrabberMotorStates(m_devices_id.revolution);
 }
 
 ManualReel RevolutionTask::getManualReelStates()
 {
-    ManualReel manual_reel;
-    if (!mMessageParser.checkDeviceMacAddress(mDevicesMacAddress.manual_reel)) {
-        throw invalid_argument("Manual reel mac address incorrect");
-    }
-    string man_reel = mDevicesMacAddress.manual_reel;
-    manual_reel.calibrated = mMessageParser.isCalibrated(man_reel);
-    manual_reel.ready = mMessageParser.isReady(man_reel);
-    manual_reel.tether_lenght = mMessageParser.getTetherLenght(man_reel);
-    manual_reel.leak = mMessageParser.isLeaking(man_reel);
-    manual_reel.cpu_temperature = mMessageParser.getCpuTemperature(man_reel);
+    string man_reel = m_devices_id.manual_reel;
 
+    ManualReel manual_reel;
+    manual_reel.tether_length = m_message_parser.getTetherLength(man_reel);
+    manual_reel.leak = m_message_parser.isLeaking(man_reel);
+    manual_reel.cpu_temperature = m_message_parser.getCpuTemperature(man_reel);
     return manual_reel;
 }
 

--- a/tasks/RevolutionTask.cpp
+++ b/tasks/RevolutionTask.cpp
@@ -85,6 +85,9 @@ void RevolutionTask::evaluateDriveCommand()
     if (port_state == RTT::NewData) {
         m_deadlines.drive = Time::now() + m_input_timeout;
     }
+    else if (port_state == RTT::NoData) {
+        return;
+    }
 
     if (Time::now() > m_deadlines.drive) {
         return;
@@ -121,21 +124,24 @@ void RevolutionTask::evaluateTiltCameraHeadCommand()
     if (port_state == RTT::NewData) {
         m_deadlines.tilt_camera_head = Time::now() + m_input_timeout;
     }
+    else if (port_state == RTT::NoData) {
+        return;
+    }
 
     if (Time::now() > m_deadlines.tilt_camera_head) {
         return;
     }
 
     if (isUnknown(m_camera_head_tilt_position)) {
-        return;
+        tilt_camera_head_command.elements[0].speed = 0;
     }
     if (m_camera_head_tilt_position >= m_camera_head_limits.upper &&
         tilt_camera_head_command.elements[0].speed > 0) {
-        return;
+        tilt_camera_head_command.elements[0].speed = 0;
     }
     if (m_camera_head_tilt_position <= m_camera_head_limits.lower &&
         tilt_camera_head_command.elements[0].speed < 0) {
-        return;
+        tilt_camera_head_command.elements[0].speed = 0;
     }
 
     string address = m_devices_id.revolution;
@@ -216,6 +222,10 @@ void RevolutionTask::evaluatePoweredReelControlCommand()
     if (port_state == RTT::NewData) {
         m_deadlines.powered_reel = Time::now() + m_input_timeout;
     }
+    else if (port_state == RTT::NoData) {
+        return;
+    }
+
     if (Time::now() > m_deadlines.powered_reel) {
         return;
     }

--- a/tasks/RevolutionTask.hpp
+++ b/tasks/RevolutionTask.hpp
@@ -103,11 +103,19 @@ namespace deep_trekker {
          */
         void cleanupHook();
 
+        struct PeriodicPortsDeadline {
+            base::Time tilt_camera_head;
+            base::Time drive;
+            base::Time powered_reel;
+        };
+
     private:
         std::string m_api_version;
         CommandAndStateMessageParser m_message_parser;
         DevicesID m_devices_id;
         DevicesModel m_devices_model;
+        base::Time m_input_timeout;
+        PeriodicPortsDeadline m_deadlines;
 
         void receiveDeviceStateInfo();
         DevicesID parseDevicesID(Json::Value const& parsed_data,
@@ -115,16 +123,19 @@ namespace deep_trekker {
 
         void evaluateCameraHeadCommand();
         void evaluateTiltCameraHeadCommand();
+        void evaluateLightCommand();
         void evaluateGrabberCommand();
         void evaluateDriveModeCommand();
         void evaluateDriveCommand();
         void evaluatePoweredReelControlCommand();
         void sendRawDataOutput(std::string control_command);
         Revolution getRevolutionStates();
+        TiltCameraHead getCameraHeadStates();
         ManualReel getManualReelStates();
         PoweredReel getPoweredReelStates();
         base::samples::RigidBodyState getRevolutionPoseZAttitude();
         base::samples::Joints getRevolutionMotorStates();
+        base::samples::Joints getCameraHeadTiltMotorState();
         base::samples::Joints getPoweredReelMotorStates();
         Grabber getGrabberMotorStates();
     };

--- a/tasks/RevolutionTask.hpp
+++ b/tasks/RevolutionTask.hpp
@@ -3,6 +3,7 @@
 #ifndef DEEP_TREKKER_REVOLUTIONTASK_TASK_HPP
 #define DEEP_TREKKER_REVOLUTIONTASK_TASK_HPP
 
+#include "base/Float.hpp"
 #include "deep_trekker/CommandAndStateMessageParser.hpp"
 #include "deep_trekker/DeepTrekkerCommands.hpp"
 #include "deep_trekker/DeepTrekkerStates.hpp"
@@ -115,6 +116,8 @@ namespace deep_trekker {
         DevicesID m_devices_id;
         DevicesModel m_devices_model;
         base::Time m_input_timeout;
+        CameraHeadLimits m_camera_head_limits;
+        double m_camera_head_tilt_position;
         PeriodicPortsDeadline m_deadlines;
 
         void receiveDeviceStateInfo();

--- a/tasks/RevolutionTask.hpp
+++ b/tasks/RevolutionTask.hpp
@@ -119,6 +119,7 @@ namespace deep_trekker {
         CameraHeadLimits m_camera_head_limits;
         double m_camera_head_tilt_position;
         PeriodicPortsDeadline m_deadlines;
+        double m_vertical_thrusters_minimum_command = 0;
 
         void receiveDeviceStateInfo();
         DevicesID parseDevicesID(Json::Value const& parsed_data,

--- a/tasks/RevolutionTask.hpp
+++ b/tasks/RevolutionTask.hpp
@@ -125,7 +125,8 @@ namespace deep_trekker {
         DevicesID parseDevicesID(Json::Value const& parsed_data,
             DevicesModel const& model);
 
-        void evaluateCameraHeadCommand();
+        void evaluateCameraHeadLightCommand();
+        void evaluateCameraHeadLaserCommand();
         void evaluateTiltCameraHeadCommand();
         void evaluateLightCommand();
         void evaluateGrabberCommand();
@@ -140,6 +141,7 @@ namespace deep_trekker {
         base::samples::RigidBodyState getRevolutionPoseZAttitude();
         base::samples::Joints getRevolutionMotorStates();
         base::samples::Joints getCameraHeadTiltMotorState();
+        base::samples::RigidBodyState getCameraHeadTiltMotorStateRBS();
         base::samples::Joints getPoweredReelMotorStates();
         Grabber getGrabberMotorStates();
     };

--- a/tasks/RevolutionTask.hpp
+++ b/tasks/RevolutionTask.hpp
@@ -104,27 +104,29 @@ namespace deep_trekker {
         void cleanupHook();
 
     private:
-        std::string mAPIVersion;
-        CommandAndStateMessageParser mMessageParser;
-        DevicesMacAddress mDevicesMacAddress;
-        MotionControllerType mMotionControllerType;
-        void evaluateMotionController();
+        std::string m_api_version;
+        CommandAndStateMessageParser m_message_parser;
+        DevicesID m_devices_id;
+        DevicesModel m_devices_model;
+
+        void receiveDeviceStateInfo();
+        DevicesID parseDevicesID(Json::Value const& parsed_data,
+            DevicesModel const& model);
+
         void evaluateCameraHeadCommand();
+        void evaluateTiltCameraHeadCommand();
         void evaluateGrabberCommand();
-        void evaluatePositionAndLightCommand();
-        void evaluateVelocityAndLightCommand();
-        void evaluateAccelerationAndLightCommand();
+        void evaluateDriveModeCommand();
+        void evaluateDriveCommand();
         void evaluatePoweredReelControlCommand();
         void sendRawDataOutput(std::string control_command);
-        void queryNewDeviceStateInfo();
-        void receiveDeviceStateInfo();
         Revolution getRevolutionStates();
         ManualReel getManualReelStates();
         PoweredReel getPoweredReelStates();
-        base::samples::RigidBodyState getRevolutionBodyStates();
+        base::samples::RigidBodyState getRevolutionPoseZAttitude();
         base::samples::Joints getRevolutionMotorStates();
         base::samples::Joints getPoweredReelMotorStates();
-        base::samples::Joints getGrabberMotorStates();
+        Grabber getGrabberMotorStates();
     };
 } // namespace deep_trekker
 

--- a/test/revolution_test.rb
+++ b/test/revolution_test.rb
@@ -17,15 +17,18 @@ describe OroGen.deep_trekker.RevolutionTask do
         @task = syskit_deploy(
             OroGen.deep_trekker
                   .RevolutionTask
-                  .deployed_as("revolution")
+                  .deployed_as_unmanaged("revolution")
         )
 
-        config = Types.deep_trekker.DevicesMacAddress.new
-        config.revolution = "57B974C0A269"
-        config.manual_reel = "578954C0A26S"
-        config.powered_reel = "63B234C0A269"
+        config = Types.deep_trekker.DevicesModel.new
+        config.revolution = 13
+        config.powered_reel = 108
+        ids = Types.deep_trekker.DevicesID.new
+        ids.revolution = "57B974C0A269"
+        ids.powered_reel = "63B234C0A269"
         @task.properties.api_version = "0.10.3"
-        @task.properties.devices_mac_address = config
+        @task.properties.devices_model = config
+        @task.properties.devices_id = ids
     end
 
     # revolution msg expected by the deep_trekker
@@ -36,49 +39,82 @@ describe OroGen.deep_trekker.RevolutionTask do
                 payload: {
                     devices: {
                         "57B974C0A269": {
-                            "currentSeconds": 2,
-                            "control": {
-                                "setpoint": {
-                                    "pose": {
-                                        "localFrame": {
-                                            "x": 1,
-                                            "y": 2,
-                                            "z": -2,
-                                            "yaw": 0.2
+                            "auxLight": { "intensity": 10 },
+                            "bodyLeak": false,
+                            "cameraHead": {
+                                "cpuTemp": 26,
+                                "ip": "10.1.1.1",
+                                "lasers": { "enabled": false },
+                                "light": { "intensity": 5 },
+                                "model": 102,
+                                "tilt": {
+                                    "position": 167.2
+                                },
+                                "tiltMotorDiagnostics": {
+                                    "current": 0,
+                                    "rpm": 10,
+                                    "pwm": 42,
+                                    "overcurrent": false
+                                },
+                                "usageTime": { "currentSeconds": 500, "totalSeconds": 10 }
+                            },
+                            "cameras": {
+                                "31028309sac": {
+                                    "ip": "10.1.1.2",
+                                    "model": 5,
+                                    "osd": { "enabled": true },
+                                    "streams": {
+                                        "blabal13123al": {
+                                            "active": true
                                         }
                                     }
                                 },
-                                "current": {
-                                    "pose": {
-                                        "localFrame": {
-                                            "x": 1,
-                                            "y": 2,
-                                            "z": -2,
-                                            "yaw": 0.2
-                                        }
-                                    }
+                                "type": "MAIN"
+                            },
+                            "cpuTemp": 43,
+                            "depth": 20,
+                            "drives": {
+                                "modes": {
+                                    "altitudeLock": false,
+                                    "autoStabilization": true,
+                                    "depthLock": false,
+                                    "headingLock": false,
+                                    "motorsDisabled": true
                                 }
-                            },
-                            "leftBattery": {
-                                "percent": 80,
-                                "voltage": 50,
-                                "charging": 20
-                            },
-                            "rightBattery": {
-                                "percent": 80,
-                                "voltage": 60,
-                                "charging": 20
                             },
                             "frontLeftMotorDiagnostics": {
                                 "current": 3,
                                 "overcurrent": false,
+                                "pwm": 20,
                                 "rpm": 5.5
                             },
                             "frontRightMotorDiagnostics": {
                                 "current": 3,
                                 "overcurrent": false,
+                                "pwm": 20,
                                 "rpm": 5.5
                             },
+                            "grabber": {
+                                "openCloseMotorDiagnostics": {
+                                    "current": 8,
+                                    "overcurrent": true,
+                                    "rpm": 5.5,
+                                    "pwm": 20
+                                },
+                                "rotateMotorDiagnostics": {
+                                    "current": 3,
+                                    "overcurrent": false,
+                                    "pwm": 20,
+                                    "rpm": 5.5
+                                }
+                            },
+                            "heading": 20,
+                            "leftBattery": {
+                                "percent": 80,
+                                "voltage": 50,
+                                "charging": true
+                            },
+                            "model": 13,
                             "rearLeftMotorDiagnostics": {
                                 "current": 3,
                                 "overcurrent": true,
@@ -89,6 +125,13 @@ describe OroGen.deep_trekker.RevolutionTask do
                                 "overcurrent": false,
                                 "rpm": 5.5
                             },
+                            "rightBattery": {
+                                "percent": 80,
+                                "voltage": 60,
+                                "charging": 20
+                            },
+                            "roll": 3,
+                            "usageTime": { "currentSeconds": 20, "totalSeconds": 20 },
                             "verticalLeftMotorDiagnostics": {
                                 "current": 3,
                                 "overcurrent": true,
@@ -98,85 +141,33 @@ describe OroGen.deep_trekker.RevolutionTask do
                                 "current": 3,
                                 "overcurrent": true,
                                 "rpm": 5.5
-                            },
-                            "auxLights": 20,
-                            "grabber": {
-                                "openCloseMotorDiagnostics": {
-                                    "current": 8,
-                                    "overcurrent": true,
-                                    "rpm": 5.5
-                                },
-                                "rollMotorDiagnostics": {
-                                    "current": 3,
-                                    "overcurrent": false,
-                                    "rpm": 5.5
-                                },
-                                "openClose": 100,
-                                "rotate": 80
-                            },
-                            "cameraHead": {
-                                "lights": 15,
-                                "lasers": true,
-                                "tilt": {
-                                    "speed": 15
-                                },
-                                "tiltMotorDiagnostics": {
-                                    "current": 3,
-                                    "overcurrent": false,
-                                    "rpm": 5.5
-                                },
-                                "camera": {
-                                    "focus": {
-                                        "value": 15
-                                    },
-                                    "brightness": 20,
-                                    "exposure": {
-                                        "value": 15
-                                    },
-                                    "saturation": 20,
-                                    "sharpness": 20,
-                                    "zoom": {
-                                        "ration": 15,
-                                        "speed": 15
-                                    }
-                                }
                             }
                         },
-                        "578954C0A26S": {
-                            "calibrator": true,
-                            "ready": true,
-                            "distance": 15,
-                            "leak": false,
-                            "cpuTemp": 10
-                        },
                         "63B234C0A269": {
-                            "calibrator": true,
-                            "ready": true,
-                            "distance": 15,
+                            "acConnected": true,
+                            "distance": 100,
                             "leak": false,
                             "cpuTemp": 10,
                             "battery1": {
                                 "percent": 80,
                                 "voltage": 10,
-                                "charging": 20
+                                "charging": true
                             },
                             "battery2": {
                                 "percent": 80,
                                 "voltage": 10,
-                                "charging": 70
+                                "charging": false
                             },
                             "motor1Diagnostics": {
                                 "current": 3,
                                 "overcurrent": false,
-                                "rpm": 5.5
+                                "pwm": 5.5
                             },
                             "motor2Diagnostics": {
                                 "current": 3,
                                 "overcurrent": false,
-                                "rpm": 5.5
+                                "pwm": 5.5
                             },
-                            "speed": 5.5,
-                            "acConnected": false,
                             "eStop": false
                         }
                     }
@@ -190,8 +181,7 @@ describe OroGen.deep_trekker.RevolutionTask do
         raw_cmd
     end
 
-    it "sends position revolution command" do
-        @task.properties.motion_controller_type = :position
+    it "sends drive revolution command" do
         syskit_configure_and_start(@task)
         raw_cmd = raw_packet_input
         # revolution cmd input
@@ -201,9 +191,7 @@ describe OroGen.deep_trekker.RevolutionTask do
         cmd.angular = Eigen::Vector3.new(0, 0, 0.2)
 
         sample = expect_execution do
-            syskit_write task.light_command_port, 0.2
-            syskit_write task.rov2ref_command_port, cmd
-            syskit_write task.data_in_port, raw_cmd
+            syskit_write task.drive_command_port, cmd
         end.to do
             have_one_new_sample(task.data_out_port).matching do |s|
                 json = JSON.parse(s.data.to_byte_array[8..-1])
@@ -213,122 +201,53 @@ describe OroGen.deep_trekker.RevolutionTask do
 
         json_from_sample = JSON.parse(sample.data.to_byte_array[8..-1])
 
-        aux_light = json_from_sample["payload"]["devices"]["57B974C0A269"]["auxLights"]
-        local_x = json_from_sample["payload"]["devices"]["57B974C0A269"]["control"] \
-                                  ["setpoint"]["pose"]["localFrame"]["x"]
-        local_y = json_from_sample["payload"]["devices"]["57B974C0A269"]["control"] \
-                                  ["setpoint"]["pose"]["localFrame"]["y"]
-        local_z = json_from_sample["payload"]["devices"]["57B974C0A269"]["control"] \
-                                  ["setpoint"]["pose"]["localFrame"]["z"]
-        local_yaw = json_from_sample["payload"]["devices"]["57B974C0A269"]["control"] \
-                                    ["setpoint"]["pose"]["localFrame"]["yaw"]
+        fwd = json_from_sample["payload"]["devices"]["57B974C0A269"]["drive"]["thrust"] \
+                              ["forward"]
+        lat = json_from_sample["payload"]["devices"]["57B974C0A269"]["drive"]["thrust"] \
+                              ["lateral"]
+        vert = json_from_sample["payload"]["devices"]["57B974C0A269"]["drive"]["thrust"] \
+                              ["vertical"]
+        yaw = json_from_sample["payload"]["devices"]["57B974C0A269"]["drive"]["thrust"] \
+                              ["yaw"]
 
-        assert_equal 0.2 * 100, aux_light # x100 before send to deep_treker
-        assert_equal 1, local_x
-        assert_equal 3, local_y
-        assert_equal 4, local_z
-        assert_equal 0.2, local_yaw
+        assert_equal 1, fwd
+        assert_equal 3, lat
+        assert_equal 4, vert
+        assert_equal 0.2, yaw
     end
 
-    it "sends velocity revolution command" do
-        @task.properties.motion_controller_type = :velocity
-        syskit_configure_and_start(@task)
-        raw_cmd = raw_packet_input
-        # revolution cmd input
-        cmd = Types.base.LinearAngular6DCommand.new
-        cmd.zero!
-        cmd.linear = Eigen::Vector3.new(1, 3, 4)
-        cmd.angular = Eigen::Vector3.new(0, 0, 0.2)
-
-        sample = expect_execution do
-            syskit_write task.light_command_port, 0.2
-            syskit_write task.rov2ref_command_port, cmd
-            syskit_write task.data_in_port, raw_cmd
-        end.to do
-            have_one_new_sample(task.data_out_port).matching do |s|
-                json = JSON.parse(s.data.to_byte_array[8..-1])
-                json["method"] == "SET"
-            end
-        end
-
-        json_from_sample = JSON.parse(sample.data.to_byte_array[8..-1])
-
-        aux_light = json_from_sample["payload"]["devices"]["57B974C0A269"]["auxLights"]
-        local_x = json_from_sample["payload"]["devices"]["57B974C0A269"]["control"] \
-                                  ["setpoint"]["velocity"]["x"]
-        local_y = json_from_sample["payload"]["devices"]["57B974C0A269"]["control"] \
-                                  ["setpoint"]["velocity"]["y"]
-        local_z = json_from_sample["payload"]["devices"]["57B974C0A269"]["control"] \
-                                  ["setpoint"]["velocity"]["z"]
-        local_yaw = json_from_sample["payload"]["devices"]["57B974C0A269"]["control"] \
-                                    ["setpoint"]["velocity"]["yaw"]
-
-        assert_equal 0.2 * 100, aux_light # x100 before send to deep_treker
-        assert_equal 1, local_x
-        assert_equal 3, local_y
-        assert_equal 4, local_z
-        assert_equal 0.2, local_yaw
-    end
-
-    it "sends acceleration revolution command" do
-        @task.properties.motion_controller_type = :acceleration
-        syskit_configure_and_start(@task)
-        raw_cmd = raw_packet_input
-        # revolution cmd input
-        cmd = Types.base.LinearAngular6DCommand.new
-        cmd.zero!
-        cmd.linear = Eigen::Vector3.new(1, 3, 4)
-        cmd.angular = Eigen::Vector3.new(0, 0, 0.2)
-
-        sample = expect_execution do
-            syskit_write task.light_command_port, 0.2
-            syskit_write task.rov2ref_command_port, cmd
-            syskit_write task.data_in_port, raw_cmd
-        end.to do
-            have_one_new_sample(task.data_out_port).matching do |s|
-                json = JSON.parse(s.data.to_byte_array[8..-1])
-                json["method"] == "SET"
-            end
-        end
-
-        json_from_sample = JSON.parse(sample.data.to_byte_array[8..-1])
-
-        aux_light = json_from_sample["payload"]["devices"]["57B974C0A269"]["auxLights"]
-        local_x = json_from_sample["payload"]["devices"]["57B974C0A269"]["control"] \
-                                  ["setpoint"]["acceleration"]["x"]
-        local_y = json_from_sample["payload"]["devices"]["57B974C0A269"]["control"] \
-                                  ["setpoint"]["acceleration"]["y"]
-        local_z = json_from_sample["payload"]["devices"]["57B974C0A269"]["control"] \
-                                  ["setpoint"]["acceleration"]["z"]
-        local_yaw = json_from_sample["payload"]["devices"]["57B974C0A269"]["control"] \
-                                    ["setpoint"]["acceleration"]["yaw"]
-
-        assert_equal 0.2 * 100, aux_light # x100 before send to deep_treker
-        assert_equal 1, local_x
-        assert_equal 3, local_y
-        assert_equal 4, local_z
-        assert_equal 0.2, local_yaw
-    end
-
-    it "sends tilt camera head command" do
-        @task.properties.motion_controller_type = :position
+    it "sends camera head command" do
         syskit_configure_and_start(@task)
         raw_cmd = raw_packet_input
         # camera head cmd input
         cmd_head = Types.deep_trekker.CameraHeadCommand.new
+        cmd_head.time = Time.now
         cmd_head.light = 0.6
         cmd_head.laser = true
-        camera = Types.deep_trekker.TamronHarrierZoomCameraCommand.new
-        camera.exposure = 1
-        camera.brightness = 1
-        camera.focus = 0.31
-        camera.saturation = 1
-        camera.sharpness = 1
-        zoom = Types.deep_trekker.ZoomControlCommand.new
-        zoom.ratio = 2
-        zoom.speed = 0.1
-        camera.zoom = zoom
-        cmd_head.camera = camera
+
+        sample = expect_execution do
+            syskit_write task.camera_head_command_port, cmd_head
+        end.to do
+            have_one_new_sample(task.data_out_port).matching do |s|
+                json = JSON.parse(s.data.to_byte_array[8..-1])
+                json["method"] == "SET"
+            end
+        end
+
+        json_from_sample = JSON.parse(sample.data.to_byte_array[8..-1])
+
+        light = json_from_sample["payload"]["devices"]["57B974C0A269"] \
+                                ["cameraHead"]["light"]["intensity"]
+        laser = json_from_sample["payload"]["devices"]["57B974C0A269"] \
+                                ["cameraHead"]["lasers"]["enabled"]
+
+        assert_equal 0.6 * 100, light # x100 before send to deep_treker
+        assert_equal true, laser
+    end
+
+    it "sends tilt camera head command" do
+        syskit_configure_and_start(@task)
+        raw_cmd = raw_packet_input
         # Tilt camera head input
         joint_state = Types.base.JointState.new
         joint_state.speed = 3.0
@@ -340,9 +259,10 @@ describe OroGen.deep_trekker.RevolutionTask do
             names: %w[joint]
         )
 
-        sample = expect_execution do
+        expect_execution do
             syskit_write task.data_in_port, raw_cmd
-            syskit_write task.camera_head_command_port, cmd_head
+        end
+        sample = expect_execution do
             syskit_write task.tilt_camera_head_command_port, cmd_tilt
         end.to do
             have_one_new_sample(task.data_out_port).matching do |s|
@@ -353,41 +273,13 @@ describe OroGen.deep_trekker.RevolutionTask do
 
         json_from_sample = JSON.parse(sample.data.to_byte_array[8..-1])
 
-        light = json_from_sample["payload"]["devices"]["57B974C0A269"] \
-                                ["cameraHead"]["lights"]
-        laser = json_from_sample["payload"]["devices"]["57B974C0A269"] \
-                                ["cameraHead"]["lasers"]
         tilt_speed = json_from_sample["payload"]["devices"]["57B974C0A269"] \
                                      ["cameraHead"]["tilt"]["speed"]
-        exposure = json_from_sample["payload"]["devices"]["57B974C0A269"] \
-                                   ["cameraHead"]["camera"]["exposure"]
-        brightness = json_from_sample["payload"]["devices"]["57B974C0A269"] \
-                                     ["cameraHead"]["camera"]["brightness"]
-        focus = json_from_sample["payload"]["devices"]["57B974C0A269"] \
-                                ["cameraHead"]["camera"]["focus"]
-        saturation = json_from_sample["payload"]["devices"]["57B974C0A269"] \
-                                     ["cameraHead"]["camera"]["saturation"]
-        sharpness = json_from_sample["payload"]["devices"]["57B974C0A269"] \
-                                    ["cameraHead"]["camera"]["sharpness"]
-        ratio = json_from_sample["payload"]["devices"]["57B974C0A269"] \
-                                ["cameraHead"]["camera"]["zoom"]["ratio"]
-        speed = json_from_sample["payload"]["devices"]["57B974C0A269"] \
-                                ["cameraHead"]["camera"]["zoom"]["speed"]
 
-        assert_equal 0.6 * 100, light # x100 before send to deep_treker
-        assert_equal true, laser
         assert_equal 1.0 * 100, tilt_speed # x100 before send to deep_treker
-        assert_equal 1 * 15, exposure # x15 before send to deep_treker
-        assert_equal 1 * 100, brightness # x100 before send to deep_treker
-        assert_in_delta 0.31 * 100, focus, 0.001 # x100 before send to deep_treker
-        assert_equal 1 * 100, saturation # x100 before send to deep_treker
-        assert_equal 1 * 100, sharpness # x100 before send to deep_treker
-        assert_equal 2, ratio
-        assert_in_delta 0.1 * 100, speed, 0.001 # x100 before send to deep_treker
     end
 
     it "sends grabber command" do
-        @task.properties.motion_controller_type = :acceleration
         syskit_configure_and_start(@task)
         raw_cmd = raw_packet_input
         # grabber cmd input
@@ -405,7 +297,6 @@ describe OroGen.deep_trekker.RevolutionTask do
         )
 
         sample = expect_execution do
-            syskit_write task.data_in_port, raw_cmd
             syskit_write task.grabber_command_port, cmd
         end.to do
             have_one_new_sample(task.data_out_port).matching do |s|
@@ -438,7 +329,6 @@ describe OroGen.deep_trekker.RevolutionTask do
         )
 
         sample = expect_execution do
-            syskit_write task.data_in_port, raw_cmd
             syskit_write task.powered_reel_command_port, cmd
         end.to do
             have_one_new_sample(task.data_out_port).matching do |s|
@@ -449,40 +339,12 @@ describe OroGen.deep_trekker.RevolutionTask do
 
         json_from_sample = JSON.parse(sample.data.to_byte_array[8..-1])
 
-        reel_forward = json_from_sample["payload"]["devices"]["63B234C0A269"]\
-                                       ["reelFoward"]
-        reel_reverse = json_from_sample["payload"]["devices"]["63B234C0A269"] \
-                                       ["reelReverse"]
         speed = json_from_sample["payload"]["devices"]["63B234C0A269"]["speed"]
 
-        assert_equal false, reel_forward
-        assert_equal true, reel_reverse
         assert_equal -0.25 * 100, speed # x100 before send to deep_treker
     end
 
-    it "sends query command for new device state info" do
-        @task.properties.motion_controller_type = :velocity
-        syskit_configure_and_start(@task)
-        raw_cmd = raw_packet_input
-
-        sample = expect_execution do
-            syskit_write task.data_in_port, raw_cmd
-        end.to do
-            have_one_new_sample(task.data_out_port).matching do |s|
-                json = JSON.parse(s.data.to_byte_array[8..-1])
-                json["method"] == "GET"
-            end
-        end
-
-        json_from_sample = JSON.parse(sample.data.to_byte_array[8..-1])
-
-        assert_equal json_from_sample["apiVersion"], "0.10.3"
-        assert_equal json_from_sample["method"], "GET"
-        assert_nil json_from_sample["payload"]
-    end
-
     it "outputs revolution states" do
-        @task.properties.motion_controller_type = :velocity
         syskit_configure_and_start(@task)
         raw_cmd = raw_packet_input
 
@@ -495,39 +357,35 @@ describe OroGen.deep_trekker.RevolutionTask do
         json_from_raw = JSON.parse(raw_cmd.data.to_byte_array[8..-1])
 
         json_root = json_from_raw["payload"]["devices"]["57B974C0A269"]
-        json_light = json_from_raw["payload"]["devices"]["57B974C0A269"] \
-                                  ["auxLights"]
+        json_aux_light = json_from_raw["payload"]["devices"]["57B974C0A269"] \
+                                  ["auxLights"]["intensity"]
         json_head = json_from_raw["payload"]["devices"]["57B974C0A269"] \
                                  ["cameraHead"]
         json_camera = json_from_raw["payload"]["devices"]["57B974C0A269"] \
                                    ["cameraHead"]["camera"]
 
-        assert_equal sample.light, json_light / 100.0
-        assert_equal sample.grabber.open_close_motor_overcurrent, 1
-        assert_equal sample.grabber.rotate_overcurrent, 0
-        assert_equal sample.camera_head.light, json_head["lights"] / 100.0
-        assert_equal sample.camera_head.laser, 1
-        assert_equal sample.camera_head.motor_overcurrent, 0
-        assert_in_delta sample.camera_head.camera.brightness, \
-                        json_camera["brightness"] / 100.0, 0.01
-        assert_equal sample.camera_head.camera.exposure, \
-                     json_camera["exposure"]["value"] / 15.0
-        assert_in_delta sample.camera_head.camera.focus, \
-                        json_camera["focus"]["value"] / 100.0, 0.01
-        assert_in_delta sample.camera_head.camera.saturation, \
-                        json_camera["saturation"] / 100.0, 0.01
-        assert_in_delta sample.camera_head.camera.sharpness, \
-                        json_camera["sharpness"] / 100.0
-        assert_equal sample.usage_time.tv_sec, json_root["currentSeconds"]
-        assert_equal sample.front_right_motor_overcurrent, 0
-        assert_equal sample.front_left_motor_overcurrent, 0
-        assert_equal sample.rear_right_motor_overcurrent, 0
-        assert_equal sample.rear_left_motor_overcurrent, 1
-        assert_equal sample.vertical_right_motor_overcurrent, 1
-        assert_equal sample.vertical_left_motor_overcurrent, 1
+        assert_equal sample.aux_light, json_aux_light / 100.0
+        assert_equal sample.grabber.open_close_motor_overcurrent, true
+        assert_equal sample.grabber.rotate_overcurrent, false
+        assert_equal sample.camera_head.light, 0.05
+        assert_equal sample.camera_head.laser, false
+        assert_equal sample.camera_head.motor_overcurrent, false
+        assert_equal sample.usage_time.tv_sec, json_root["usageTime"]["currentSeconds"]
+        assert_equal sample.front_right_motor_overcurrent, false
+        assert_equal sample.front_left_motor_overcurrent, false
+        assert_equal sample.rear_right_motor_overcurrent, false
+        assert_equal sample.rear_left_motor_overcurrent, true
+        assert_equal sample.vertical_right_motor_overcurrent, true
+        assert_equal sample.vertical_left_motor_overcurrent, true
         assert_in_delta sample.left_battery.charge,
                         json_root["leftBattery"]["percent"] / 100.0, 0.01
         assert_in_delta sample.right_battery.charge,
                         json_root["rightBattery"]["percent"] / 100.0, 0.01
+        assert_equal sample.drive_modes.altitude_lock, false
+        assert_equal sample.drive_modes.heading_lock, false
+        assert_equal sample.drive_modes.depth_lock, false
+        assert_equal sample.drive_modes.auto_stabilization, true
+        assert_equal sample.drive_modes.motors_disabled, true
+        assert_equal sample.cpu_temperature, 43
     end
 end


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-deep_trekker/pull/10
- [ ] https://github.com/tidewise/bundles-rov/pull/47

I removed the old control commands, which are no longer valid according to the API. The feedback no longer requires a GET request to be sent beforehand, because of that there may be some missing fields in the message we receive. To account for this, I throw an exception whenever a field is missing, right now I am just ignoring this exception and continuing with the logic.