### PR TITLE
fix: set input timeout to 0 in camera tilt head cmd limit test

### DIFF
--- a/tasks/RevolutionTask.cpp
+++ b/tasks/RevolutionTask.cpp
@@ -82,14 +82,15 @@ void RevolutionTask::evaluateDriveCommand()
 {
     base::commands::LinearAngular6DCommand drive;
     auto port_state = _drive_command.read(drive);
+    auto now = Time::now();
     if (port_state == RTT::NewData) {
-        m_deadlines.drive = Time::now() + m_input_timeout;
+        m_deadlines.drive = now + m_input_timeout;
     }
     else if (port_state == RTT::NoData) {
         return;
     }
 
-    if (Time::now() > m_deadlines.drive) {
+    if (now > m_deadlines.drive) {
         return;
     }
 
@@ -121,14 +122,16 @@ void RevolutionTask::evaluateTiltCameraHeadCommand()
 {
     samples::Joints tilt_camera_head_command;
     auto port_state = _tilt_camera_head_command.read(tilt_camera_head_command);
+    // Register the time once, allowing for an input timeout of 0
+    Time now = Time::now();
     if (port_state == RTT::NewData) {
-        m_deadlines.tilt_camera_head = Time::now() + m_input_timeout;
+        m_deadlines.tilt_camera_head = now + m_input_timeout;
     }
     else if (port_state == RTT::NoData) {
         return;
     }
 
-    if (Time::now() > m_deadlines.tilt_camera_head) {
+    if (now > m_deadlines.tilt_camera_head) {
         return;
     }
 
@@ -219,14 +222,15 @@ void RevolutionTask::evaluatePoweredReelControlCommand()
 {
     samples::Joints powered_reel_command;
     auto port_state = _powered_reel_command.read(powered_reel_command);
+    auto now = Time::now();
     if (port_state == RTT::NewData) {
-        m_deadlines.powered_reel = Time::now() + m_input_timeout;
+        m_deadlines.powered_reel = now + m_input_timeout;
     }
     else if (port_state == RTT::NoData) {
         return;
     }
 
-    if (Time::now() > m_deadlines.powered_reel) {
+    if (now > m_deadlines.powered_reel) {
         return;
     }
 

--- a/tasks/RevolutionTask.cpp
+++ b/tasks/RevolutionTask.cpp
@@ -192,7 +192,7 @@ void RevolutionTask::evaluateCameraHeadLaserCommand()
 void RevolutionTask::evaluateLightCommand()
 {
     double intensity;
-    if (_camera_head_light.read(intensity) == RTT::NoData) {
+    if (_light_command.read(intensity) == RTT::NoData) {
         return;
     }
 

--- a/test/revolution_test.rb
+++ b/test/revolution_test.rb
@@ -220,6 +220,21 @@ describe OroGen.deep_trekker.RevolutionTask do
         assert_equal 20, yaw
     end
 
+    it "sends auxiliary light command" do
+        syskit_configure_and_start(@task)
+        cmd = 0.4
+
+        sample = expect_execution do
+            syskit_write task.light_command_port, cmd
+        end.to do
+            have_one_new_sample(task.data_out_port).matching do |s|
+                json = JSON.parse(s.data.to_byte_array[8..-1])
+                aux_light = json["payload"]["devices"]["57B974C0A269"]["auxLight"]
+                aux_light["intensity"] == 40
+            end
+        end
+    end
+
     it "sends camera light command" do
         syskit_configure_and_start(@task)
         cmd = 0.6

--- a/test/revolution_test.rb
+++ b/test/revolution_test.rb
@@ -516,10 +516,6 @@ describe OroGen.deep_trekker.RevolutionTask do
         json_root = json_from_raw["payload"]["devices"]["57B974C0A269"]
         json_aux_light = json_from_raw["payload"]["devices"]["57B974C0A269"] \
                                   ["auxLight"]["intensity"]
-        json_head = json_from_raw["payload"]["devices"]["57B974C0A269"] \
-                                 ["cameraHead"]
-        json_camera = json_from_raw["payload"]["devices"]["57B974C0A269"] \
-                                   ["cameraHead"]["camera"]
 
         assert_equal sample.aux_light, json_aux_light / 100.0
         assert_equal sample.usage_time.tv_sec, json_root["usageTime"]["currentSeconds"]


### PR DESCRIPTION
When the timeout is not 0, there's a chance that one of the previous commands is being processed as a new command is issued. This one result in a different sample than the expectation.

Also, auxiliary light was reading the wrong port. It didnt have a unit test, so that wasnt breaking the tests. Fixed and added a unit test.