### PR TITLE
chore: output the tether length as double to remove a conversion done within Syskit

### DIFF
--- a/deep_trekker.orogen
+++ b/deep_trekker.orogen
@@ -64,6 +64,8 @@ task_context "RevolutionTask" do
     output_port "grabber_motor_states", "deep_trekker/Grabber"
     # Powered reel states
     output_port "powered_reel_states", "deep_trekker/PoweredReel"
+    # Tether length
+    output_port "tether_length", "double"
     # Powered reel motor states
     output_port "powered_reel_motor_states", "base/samples/Joints"
     # Manual reel states

--- a/tasks/RevolutionTask.cpp
+++ b/tasks/RevolutionTask.cpp
@@ -288,8 +288,11 @@ void RevolutionTask::receiveDeviceStateInfo()
     }
 
     if (!m_devices_id.powered_reel.empty()) {
-        tryParseAndWriteIgnoringExceptions(
-            [&]() { _powered_reel_states.write(getPoweredReelStates()); });
+        tryParseAndWriteIgnoringExceptions([&]() {
+            auto state = getPoweredReelStates();
+            _tether_length.write(state.tether_length);
+            _powered_reel_states.write(state);
+        });
         tryParseAndWriteIgnoringExceptions(
             [&]() { _powered_reel_motor_states.write(getPoweredReelMotorStates()); });
     }


### PR DESCRIPTION
This is not the right type, but that's better than the current situation