### PR TITLE
fix: replace NaN with 0

### DIFF
--- a/tasks/RevolutionTask.hpp
+++ b/tasks/RevolutionTask.hpp
@@ -128,6 +128,7 @@ namespace deep_trekker {
         std::vector<GetRequestConfig> m_get_requests;
         base::Quaterniond m_nwu_magnetic2nwu_ori;
         base::MatrixXd m_compensation_matrix;
+        base::commands::LinearAngular6DCommand m_compensated_command;
 
         void receiveDeviceStateInfo();
         DevicesID parseDevicesID(Json::Value const& parsed_data,


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-deep_trekker/pull/21

When the ROV is doing the dive mission, the x and y position is NaN since there is no source of these information, it was causing error in the matrix multiplication. So we decided to replace NaN with 0 to deal with it.