### PR TITLE
fix: remove source and target frame

### DIFF
--- a/tasks/RevolutionTask.cpp
+++ b/tasks/RevolutionTask.cpp
@@ -337,10 +337,7 @@ void RevolutionTask::receiveDeviceStateInfo()
         tryParseAndWriteIgnoringExceptions(
             [&]() { _camera_head_tilt_states.write(getCameraHeadTiltMotorState()); });
         tryParseAndWriteIgnoringExceptions([&]() {
-            auto camera_head_rbs = getCameraHeadTiltMotorStateRBS();
-            camera_head_rbs.sourceFrame = "deep_trekker::body2front_camera_pre";
-            camera_head_rbs.targetFrame = "deep_trekker::body2front_camera_post";
-            _camera_head_tilt_states_rbs.write(camera_head_rbs);
+            _camera_head_tilt_states_rbs.write(getCameraHeadTiltMotorStateRBS());
         });
         tryParseAndWriteIgnoringExceptions(
             [&]() { _grabber_motor_states.write(getGrabberMotorStates()); });


### PR DESCRIPTION
That is now done in the library (we also noticed that they were wrong). It was supposed to be post2pre.

Related to https://github.com/tidewise/drivers-deep_trekker/pull/20