### PR TITLE
feat: report compensated command in its own port

### DIFF
--- a/deep_trekker.orogen
+++ b/deep_trekker.orogen
@@ -93,6 +93,8 @@ task_context "RevolutionTask" do
     output_port "motors_disabled_state", "bool"
     # Whether auto stabilization is enabled
     output_port "auto_stabilization_state", "bool"
+    # The command issued to the ROV after compensation
+    output_port "command", "base/commands/LinearAngular6DCommand"
 
     periodic 0.005
 end

--- a/deep_trekker.orogen
+++ b/deep_trekker.orogen
@@ -41,6 +41,8 @@ task_context "RevolutionTask" do
     # Describes what's the update interval to send get requests for specific data in the
     # API.
     property "get_requests_intervals", "deep_trekker/GetRequestsIntervals"
+    # Magnetic declination, added to the heading reported by the ROV
+    property "nwu_magnetic2nwu", "/base/Angle"
 
     # Tilt camera head position/speed joint command
     input_port "tilt_camera_head_command", "base/samples/Joints"
@@ -73,8 +75,6 @@ task_context "RevolutionTask" do
     output_port "camera_head_tilt_states_rbs", "base/samples/RigidBodyState"
     # Revolution states
     output_port "revolution_states", "deep_trekker/Revolution"
-    # Magnetic declination, added to the heading reported by the ROV
-    property "nwu_magnetic2nwu", "/base/Angle"
     # Revolution pose (z and attitude)
     output_port "revolution_pose_z_attitude", "base/samples/RigidBodyState"
     # Revolution motor states

--- a/tasks/RevolutionTask.cpp
+++ b/tasks/RevolutionTask.cpp
@@ -179,14 +179,15 @@ void RevolutionTask::evaluateDriveCommand()
             true);
     sendRawDataOutput(enable_auto_stabilization);
 
-    m_compensated_command = compensateDriveCommand(drive);
+    auto compensated_command = compensateDriveCommand(drive);
 
     string drive_command =
         m_message_parser.parseDriveRevolutionCommandMessage(m_api_version,
             m_devices_id.revolution,
             m_devices_model.revolution,
-            m_compensated_command);
+            compensated_command);
     sendRawDataOutput(drive_command);
+    _command.write(compensated_command);
 }
 
 void RevolutionTask::evaluateDriveModeCommand()
@@ -429,7 +430,6 @@ Revolution RevolutionTask::getRevolutionStates()
     revolution.vertical_left_motor_overcurrent =
         m_message_parser.getMotorOvercurrentStates(rev_address,
             "verticalLeftMotorDiagnostics");
-    revolution.compensated_command = m_compensated_command;
 
     revolution.left_battery =
         m_message_parser.getBatteryStates(rev_address, "leftBattery");

--- a/tasks/RevolutionTask.hpp
+++ b/tasks/RevolutionTask.hpp
@@ -128,7 +128,6 @@ namespace deep_trekker {
         std::vector<GetRequestConfig> m_get_requests;
         base::Quaterniond m_nwu_magnetic2nwu_ori;
         base::MatrixXd m_compensation_matrix;
-        base::commands::LinearAngular6DCommand m_compensated_command;
 
         void receiveDeviceStateInfo();
         DevicesID parseDevicesID(Json::Value const& parsed_data,

--- a/test/revolution_test.rb
+++ b/test/revolution_test.rb
@@ -275,6 +275,27 @@ describe OroGen.deep_trekker.RevolutionTask do
         assert_equal -20, yaw
     end
 
+    it "writes the compensated command" do
+        syskit_configure_and_start(@task)
+        cmd = Types.base.LinearAngular6DCommand.new
+        cmd.zero!
+        cmd.linear = Eigen::Vector3.new(1, 0.3, 0.4)
+        cmd.angular = Eigen::Vector3.new(0, 0, 0.2)
+
+        expect_execution do
+            syskit_write task.drive_command_port, cmd
+        end.to do
+            have_one_new_sample(task.command_port).matching do |c|
+                assert_in_delta 1, c.linear.x, 1e-3
+                assert_in_delta 0.33, c.linear.y, 1e-3
+                assert_in_delta 0.3, c.linear.z, 1e-3
+                assert_in_delta 0, c.angular.x, 1e-3
+                assert_in_delta 0, c.angular.y, 1e-3
+                assert_in_delta 0.2, c.angular.z, 1e-3
+            end
+        end
+    end
+
     it "turns auto stabilization off when the drive command port is not connected" do
         syskit_configure_and_start(@task)
 


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
Pose estimation needs the command that the ROV executed, so this PR adds it as a separate port.

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
- [x] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
